### PR TITLE
feat(storage): improve handling of storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 vendor
 vm-images/qcow-efi/nixinit-bootstrap.qcow2
 configuration.nix
+cidata

--- a/cmd/nixinit/cmd/remove-bootstraps.go
+++ b/cmd/nixinit/cmd/remove-bootstraps.go
@@ -10,14 +10,9 @@ import (
 // removeBootstrapsCmd represents the removeBootstraps command
 var removeBootstrapsCmd = &cobra.Command{
 	Use:   "remove-bootstraps",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: removeBootstraps,
+	Short: "Removes an existing nixinit bootstrap machine",
+	Long:  `Removes an existing nixinit bootstrap machine`,
+	Run:   removeBootstraps,
 }
 
 var removeInstanceID string


### PR DESCRIPTION
Modifications:
- add support for two storage pools - `nixinit-volumes` and `nixinit-iso`
- remove vol from above storage pool when deleting instance
- remove iso from storage pool when deleting instance
- this PR now enables a much simpler flow of creating a bootstrap, listing bootstraps and removing them and the main parts are cleaned up such that it can simply be run all over again.

Closes #5.