### PR TITLE
feat(service-flake): add flake for nixinit service

### DIFF
--- a/service-flake/flake.nix
+++ b/service-flake/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "A simple flake which builds the nixinit-service package and adds it as a module";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05-small";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+
+      overlayList = [ self.overlays.default ];
+
+      pkgsBySystem = forEachSystem (
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = overlayList;
+        }
+      );
+
+    in
+    rec {
+
+      # A Nixpkgs overlay that provides a 'simple-go-webserver' package.
+      overlays.default = final: prev: { nixinit-server = final.callPackage ./packages/nixinit-server.nix { }; };
+
+      packages = forEachSystem (system: {
+        nixinit-server = pkgsBySystem.${system}.nixinit-server;
+        default = pkgsBySystem.${system}.nixinit-server;
+      });
+
+      nixosModules = import ./nixos-modules { overlays = overlayList; };
+
+    };
+}

--- a/service-flake/nixos-modules/default.nix
+++ b/service-flake/nixos-modules/default.nix
@@ -1,0 +1,13 @@
+{ overlays }:
+
+{
+  nixinit = import ./nixinit-server-service.nix;
+
+  overlayNixpkgsForThisInstance =
+    { pkgs, ... }:
+    {
+      nixpkgs = {
+        inherit overlays;
+      };
+    };
+}

--- a/service-flake/nixos-modules/nixinit-server-service.nix
+++ b/service-flake/nixos-modules/nixinit-server-service.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  pkgs,
+  lib ? pkgs.lib,
+  ...
+}:
+
+with lib;
+
+let
+
+  cfg = config.services.nixinit ;
+
+in
+
+{
+  ###### interface
+  options = {
+
+    services.nixinit = rec {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to run the nixinit-server
+        '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 8080;
+        description = ''
+          The port to run the service on
+        '';
+      };
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    users.extraGroups.nixinit = { };
+
+    users.extraUsers.nixinit = {
+      description = "nixinit";
+      group = "nixinit";
+      home = "/home/nixinit";
+      createHome = true;
+      isSystemUser = true;
+      useDefaultShell = true;
+    };
+
+    environment.systemPackages = [ pkgs.nixinit-server ];
+
+    systemd.services.nixinit = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        # the binary generated in this repo is called simple-rest-api and not
+        # simple-go-server.
+        ExecStart = "+${pkgs.nixinit-server}/bin/nixinit-server";
+        User = "nixinit";
+        PermissionsStartOnly = true;
+        Restart = "always";
+        WorkingDirectory = "/home/nixinit";
+      };
+    };
+  };
+}

--- a/service-flake/packages/nixinit-server.nix
+++ b/service-flake/packages/nixinit-server.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "nixinit-server";
+  # this package currently has no tags
+  version = "0.0.0";
+
+  src = fetchFromGitHub {
+    owner = "seanrmurphy";
+    repo = "nixinit";
+    rev = "3516473";
+    hash = "sha256-lYKydutQvvK2h2pFTojLS5as4xIP7HA2W3qL3P8pK/I=";
+  };
+
+  vendorHash = "sha256-rbQPfp5rEwUV5GQKw2HDZvI9dO1axOX23U7Ko6pCQxc=";
+
+  subCommands = [ "cmd/nixinit-server" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "nixinit-server - a service for bringing up nix";
+    homepage = "https://github.com/seanrmurphy/nixinit";
+    mainProgram = "nixinit-server";
+  };
+}

--- a/vm-images/common/configuration.nix
+++ b/vm-images/common/configuration.nix
@@ -47,6 +47,8 @@
     };
   };
 
+  services.nixinit.enable = true;
+
   # TODO: Configure your system-wide user settings (groups, etc), add more users as needed.
   users.users = {
     test-user = {

--- a/vm-images/qcow/flake.lock
+++ b/vm-images/qcow/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "nixinit-server": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "dir": "service-flake",
+        "lastModified": 1725896671,
+        "narHash": "sha256-ZgeLKyrstKMJWB0y8gPWNPadTrp0Lx9MFm5Fuzg3CmI=",
+        "owner": "seanrmurphy",
+        "repo": "nixinit",
+        "rev": "ec954a32b139d661dba9ecd43609bf24b72e1239",
+        "type": "github"
+      },
+      "original": {
+        "dir": "service-flake",
+        "owner": "seanrmurphy",
+        "ref": "add-flake-for-service",
+        "repo": "nixinit",
+        "type": "github"
+      }
+    },
     "nixlib": {
       "locked": {
         "lastModified": 1722128034,
@@ -38,6 +59,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1725858438,
+        "narHash": "sha256-8VRI+yaSBlR3u0rV9eBPJls0mfCyuNXtb1LxdaW2RuA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d4a22bbfc1db9ba06dd1acc03e0160b8a18ce6ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1722062969,
         "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
         "owner": "NixOS",
@@ -53,8 +90,9 @@
     },
     "root": {
       "inputs": {
+        "nixinit-server": "nixinit-server",
         "nixos-generators": "nixos-generators",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/vm-images/qcow/flake.nix
+++ b/vm-images/qcow/flake.nix
@@ -1,20 +1,38 @@
 {
+
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixinit-server.url = "github:seanrmurphy/nixinit/add-flake-for-service?dir=service-flake";
     nixos-generators = {
       url = "github:nix-community/nixos-generators";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
-  outputs = { self, nixpkgs, nixos-generators, ... }: {
+
+  outputs = { self, nixpkgs, nixos-generators, nixinit-server, ... }: {
     packages.x86_64-linux = {
       qcow = nixos-generators.nixosGenerate {
         system = "x86_64-linux";
         modules = [
           # you can include your own nixos configuration here, i.e.
           ./configuration.nix
+          nixinit-server.nixosModules.nixinit
+        ({ pkgs, ... }: {
+          nixpkgs.overlays = [
+            nixinit-server.overlays.default
+          ];
+          # Add the packages from nixinit-server here
+          environment.systemPackages = with pkgs; [
+            # Add the packages you want from nixinit-server
+            # For example:
+            nixinit-server.packages.x86_64-linux.nixinit-server
+            # Add more packages as needed
+          ];
+        })
         ];
         format = "qcow";
+
+        # pkgs = import nixpkgs { overlays = [ nixinit-server.overlays.default ]; };
 
         # optional arguments:
         # explicit nixpkgs and lib:

--- a/vm-images/qcow/make-image.sh
+++ b/vm-images/qcow/make-image.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 
-nix build .#qcow
+nix build --show-trace .#qcow


### PR DESCRIPTION
This PR adds the following:
- a flake in the `service-flake` directory which supports creating a package and a service.
- logic to add the package and the service to the vm image build for the qcow image type

This image gets built and booted and the service runs.

Changes are required to the service to enable it to run properly but the flake creation and adding to the image build is now working.

